### PR TITLE
Fixed duplicate line items by removing line 187 of profile.py

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,7 +184,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- removed " cart["order"]["line_items"] = line_items.data " from line 187

## Requests / Responses

**Request**

GET http://localhost:8000/profile/cart

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] GET http://localhost:8000/profile/cart
- [ ] Verify Line Items is only populated once and no line_items property exists.
- [ ] Verify Size is accurate to amount of objects in cart

## Related Issues

- Fixes #24 