### PR TITLE
Reversed error where create date and exp date were swapped.

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
## Changes

- Swapped the date being passed in on 37 and 38. 37 now receives exp date and 38 create date 

## Requests / Responses

**Request**

```json
{
    "merchant_name": "Visa",
    "account_number": "000000000000",
    "expiration_date": "2025-01-31",
    "create_date": "2020-10-17"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/paymenttypes/4",
    "merchant_name": "Visa",
    "account_number": "000000000000",
    "expiration_date": "2025-01-31",
    "create_date": "2020-10-17"
}
```

## Testing

Description of how to test code...

- [ ] Run a POST to http://localhost:8000/paymenttypes
- [ ] Verify that the data sent to app is the data you get back


## Related Issues

- Fixes #19 